### PR TITLE
Don't call i18n_enabled? from seeds file if it isn't available

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-(Refinery.i18n_enabled? ? Refinery::I18n.frontend_locales : [:en]).each do |lang|
+(Refinery.respond_to?(:i18n_enabled?) && Refinery.i18n_enabled? ? Refinery::I18n.frontend_locales : [:en]).each do |lang|
   I18n.locale = lang
 
   if defined?(Refinery::User)


### PR DESCRIPTION
This fixes #2, which occurs with Refinery v2.1.
