### PR TITLE
Fix I18n check

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-(Refinery.respond_to?(:i18n_enabled?) && Refinery.i18n_enabled? ? Refinery::I18n.frontend_locales : [:en]).each do |lang|
+Refinery::I18n.frontend_locales.each do |lang|
   I18n.locale = lang
 
   if defined?(Refinery::User)


### PR DESCRIPTION
My previous pull request didn't really fix this, It just silenced the error message. I modeled this after the seeds file that the new Refinery 2.1's extension generator produces, so it seems that this is the "proper" way now.

My only concern is that this might not work with Refinery 2.0 if I18n isn't enabled, but maybe that's a small enough number of users as to not warrant being overly defensive here. If you do want to be more defensive on this, replacing the first line with something like this might work too:

``` ruby
(Refinery.const_defined?('I18n') ? Refinery::I18n.frontend_locales : [:en]).each do |lang|
```

I'll defer to you on this though. If you feel like the current changes are sufficient and merge it, great. If you want me to change it first to use the check above, let me know and I will make that change before you merge it.
