### PR TITLE
draw route instead of append

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Refinery::Core::Engine.routes.append do
+Refinery::Core::Engine.routes.draw do
 
   # Frontend routes
   namespace :dynamicfields do


### PR DESCRIPTION
Fix routing for `/refinery/dynamicfields` in refinery '~> 4.0.0'

Related with:
https://github.com/refinery/refinerycms-authentication-devise/issues/28